### PR TITLE
refactor jest to deploy new contract to new account every test

### DIFF
--- a/packages/contracts/jest.config.js
+++ b/packages/contracts/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   verbose: true,
   automock: false,
   collectCoverage: true,
-  testTimeout: 20000,
+  testTimeout: 50000,
   transform: {
     ...tsjPreset.transform,
   },

--- a/packages/contracts/tests/greeting.spec.ts
+++ b/packages/contracts/tests/greeting.spec.ts
@@ -1,18 +1,33 @@
 import "jest";
-import { Account, connect, Contract, KeyPair } from "near-api-js";
+import fs from "fs";
+import path from "path";
+import { Account, connect, Contract, KeyPair, Near } from "near-api-js";
 import { UrlAccountCreator } from "near-api-js/lib/account_creator";
 import { InMemoryKeyStore } from "near-api-js/lib/key_stores";
+import { NearConfig } from "near-api-js/lib/near";
 import { v4 } from "uuid";
 import { GreetingContract } from "../lib";
 
-const config = {
+const config: NearConfig = {
   networkId: "testnet",
   nodeUrl: "https://rpc.testnet.near.org",
-  contractName: "dev-1652055476064-95220052886384",
   walletUrl: "https://wallet.testnet.near.org",
   helperUrl: "https://helper.testnet.near.org",
-  explorerUrl: "https://explorer.testnet.near.org",
 };
+
+const createTestAccount = async (params: {near: Near, config: NearConfig, keyStore: InMemoryKeyStore}): Promise<Account> => {
+    const UrlCreator = new UrlAccountCreator(params.near.connection, params.config.helperUrl!);
+
+    const accountId = `${v4()}.testnet`;
+    const randomKey = KeyPair.fromRandom("ed25519");
+
+    await UrlCreator.createAccount(accountId, randomKey.getPublicKey());
+
+    params.keyStore.setKey(config.networkId, accountId, randomKey);
+
+    const account = await params.near.account(accountId);
+    return account;
+}
 
 describe("Greeting Contract Tests", () => {
   let contract: GreetingContract;
@@ -24,19 +39,13 @@ describe("Greeting Contract Tests", () => {
 
     const near = await connect({ ...config, keyStore });
 
-    const UrlCreator = new UrlAccountCreator(near.connection, config.helperUrl);
+    const contractAccount = await createTestAccount({near, config, keyStore});
+    account = await createTestAccount({near, config, keyStore});
 
-    const accountId = `${v4()}.testnet`;
-    const randomKey = await KeyPair.fromRandom("ed25519");
+    await contractAccount.deployContract(fs.readFileSync(path.resolve(__dirname, "../out/contract.wasm")));
 
-    await UrlCreator.createAccount(accountId, randomKey.getPublicKey());
-
-    keyStore.setKey(config.networkId, accountId, randomKey);
-
-    account = await near.account(accountId);
-
-    contract = await new GreetingContract(
-      new Contract(account, config.contractName, {
+    contract = new GreetingContract(
+      new Contract(account, contractAccount.accountId, {
         viewMethods: ["get_greeting"],
         changeMethods: ["set_greeting"],
       })
@@ -50,7 +59,6 @@ describe("Greeting Contract Tests", () => {
       account_id: account.accountId,
     });
 
-    console.log(message);
 
     expect(message).toEqual("Hello");
   });


### PR DESCRIPTION
### What does it do?
Changes the way jest tests for the contract are run. Instead of always redeploying to the same account (which keeps previous contract state) now the tests create a new account on every run and deploy a contract to it.

### Any helpful background information?
Had to increase timeout for tests to 50s.
Had to refactor account creation on testnet to a new function


### Any new dependencies? Why were they added?
No

### Relevant screenshots/gifs
No

### Does it close any issues?
No